### PR TITLE
default slider.maxDiffInc to 2

### DIFF
--- a/components/payment-popup/log-slider.js
+++ b/components/payment-popup/log-slider.js
@@ -144,7 +144,7 @@ export function NewContentSliderCtrl(CBV, ranksCtrl, WidgetProps) {
 	sliderSpace = MaxBoost(
 		sliderSpace, 
 		ranksCtrl.empty ? sliderSpace.MinBoost+40 : null, 
-		WidgetProps.slider.maxDiffInc || 1.25
+		WidgetProps.slider.maxDiffInc
 	);
 	sliderSpace = ExtendedSpaceSize(sliderSpace);
 	sliderSpace.content = {

--- a/lib/api-compatibility.js
+++ b/lib/api-compatibility.js
@@ -77,7 +77,7 @@ const WalletsLib = require('./wallets');
 			maxMarkers: 15, // sliderMarkersMaxCount
 			rankMarkers: [],
 			logScale: false,
-			maxDiffInc: 1.25
+			maxDiffInc: 2
 		},
 		wallets: {
 			available: ['moneybutton', 'relayx'], // wallets
@@ -310,6 +310,7 @@ function normalizeSlider(opts) {
 	o.sliderStep = opts.sliderDiffStep > 0 ? opts.sliderDiffStep : o.sliderStep || 1;
 	o.markerStep = opts.sliderDiffMarkerStep > 0 ? opts.sliderDiffMarkerStep : o.markerStep || 10;
 	o.maxMarkers = opts.sliderMarkersMaxCount > 0 ? opts.sliderMarkersMaxCount : o.maxMarkers || 15;
+	o.maxDiffInc = opts.maxDiffInc > 0 ? opts.maxDiffInc : o.maxDiffInc || 2;
 	return o;
 }
 

--- a/lib/boost-helpers.js
+++ b/lib/boost-helpers.js
@@ -87,7 +87,7 @@ export const fetchBoostsApi = async props => {
 		return res;
 	}
 	//
-	let counts = analizeBoosts(boostSearch, props.diff.maxDiffInc || 1.25); // from 80% to 100%
+	let counts = analizeBoosts(boostSearch, props.slider.maxDiffInc);
 	res.diff = {
 		...props.diff,
 		...{ min: counts.min, max: counts.incMax, initial: counts.max }


### PR DESCRIPTION
updated default setting for slider.maxDiffInc to 2, previous value of 1.25 was in two places so moved that into api-compatibility.js. one of those lines referred to props.diff.maxDiffInc, believe that was meant to be slider.maxDiffInc.